### PR TITLE
removeLayer was clearing all the overlay layers..

### DIFF
--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -59,6 +59,7 @@ L.Control.GroupedLayers = L.Control.extend({
   removeLayer: function (layer) {
     var id = L.Util.stamp(layer);
     delete this._layers[id];
+    this._domGroups.length=0;
     this._update();
     return this;
   },


### PR DESCRIPTION
and not repopulating them in the layer control.  This was happening because groupContainer on line 225 was not null, so the "Create the group container if it doesn't exist" section will never be executed, and the innerHTML never populated
