### PR TITLE
Add ability for grouped layers to be exclusive.

### DIFF
--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -7,7 +7,8 @@ L.Control.GroupedLayers = L.Control.extend({
   options: {
     collapsed: true,
     position: 'topright',
-    autoZIndex: true
+    autoZIndex: true,
+    exclusiveGroups: []
   },
 
   initialize: function (baseLayers, groupedOverlays, options) {
@@ -131,9 +132,12 @@ L.Control.GroupedLayers = L.Control.extend({
       groupId = this._groupList.push(group) - 1;
     }
 
+    var exclusive = (this.options.exclusiveGroups.indexOf(group) != -1);
+
     this._layers[id].group = {
       name: group,
-      id: groupId
+      id: groupId,
+      exclusive: exclusive
     };
 
     if (this.options.autoZIndex && layer.setZIndex) {
@@ -205,10 +209,15 @@ L.Control.GroupedLayers = L.Control.extend({
         container;
 
     if (obj.overlay) {
-      input = document.createElement('input');
-      input.type = 'checkbox';
-      input.className = 'leaflet-control-layers-selector';
-      input.defaultChecked = checked;
+      if (obj.group.exclusive) {
+        groupRadioName = 'leaflet-exclusive-group-layer-' + obj.group.id;
+        input = this._createRadioElement(groupRadioName, checked);
+      } else {
+        input = document.createElement('input');
+        input.type = 'checkbox';
+        input.className = 'leaflet-control-layers-selector';
+        input.defaultChecked = checked;
+      }
     } else {
       input = this._createRadioElement('leaflet-base-layers', checked);
     }


### PR DESCRIPTION
Simple modification that allows to specify exclusive layer groups by adding the
name of the group to to options.exclusiveGroups.
This resolves ismyrnow/Leaflet.groupedlayercontrol#2
and can be used to gain the functionality discussed in Leaflet/Leaflet#593
