### PR TITLE
fix zIndex position overlay with base layers

### DIFF
--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -276,7 +276,9 @@ L.Control.GroupedLayers = L.Control.extend({
 
       if (input.checked && !this._map.hasLayer(obj.layer)) {
         this._map.addLayer(obj.layer);
-
+			    if(!obj.overlay) {
+				    obj.layer.setZIndex(0);
+				  }
       } else if (!input.checked && this._map.hasLayer(obj.layer)) {
         this._map.removeLayer(obj.layer);
       }


### PR DESCRIPTION
Fix zIndex position overlay with base layers when L.control.groupedLayers panels separate on two or more panels (with overlay and base layers). Example: http://jsfiddle.net/q77wk17z/1/ - overlay layer don't visible when change base layer; http://spatialhast.github.io/leaflet.groupedlayercontrol.html - work example with fixed zIndex ordering.