### PR TITLE
SELECT (dropdown) alternative to radio buttons.

### DIFF
--- a/example/basic2.html
+++ b/example/basic2.html
@@ -1,0 +1,77 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+  <title>Basic Example</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+  <link rel="stylesheet" href="../src/leaflet.groupedlayercontrol.css" />
+</head>
+<body>
+  <div id="map" style="width: 600px; height: 400px"></div>
+
+  <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+  <script src="../src/leaflet.groupedlayercontrol.js"></script>
+  <script>
+    var cities = new L.LayerGroup();
+    L.marker([39.61, -105.02]).bindPopup('Littleton, CO.').addTo(cities);
+    L.marker([39.74, -104.99]).bindPopup('Denver, CO.').addTo(cities);
+    L.marker([39.73, -104.8]).bindPopup('Aurora, CO.').addTo(cities);
+    L.marker([39.77, -105.23]).bindPopup('Golden, CO.').addTo(cities);
+
+    var restaurants = new L.LayerGroup();
+    L.marker([39.69, -104.85]).bindPopup('A restaurant').addTo(restaurants);
+    L.marker([39.69, -105.12]).bindPopup('A restaurant').addTo(restaurants);
+
+    var dogs = new L.LayerGroup();
+    L.marker([39.79, -104.95]).bindPopup('A dog').addTo(dogs);
+    L.marker([39.79, -105.22]).bindPopup('A dog').addTo(dogs);
+
+    var cats = new L.LayerGroup();
+    L.marker([39.59, -104.75]).bindPopup('A cat').addTo(cats);
+    L.marker([39.59, -105.02]).bindPopup('A cat').addTo(cats);
+
+    var mbAttr = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+        '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+        'Imagery � <a href="http://mapbox.com">Mapbox</a>',
+      mbUrl = 'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png';
+
+    var grayscale   = L.tileLayer(mbUrl, {id: 'examples.map-20v6611k', attribution: mbAttr}),
+      streets  = L.tileLayer(mbUrl, {id: 'examples.map-i875mjb7',   attribution: mbAttr});
+
+    var map = L.map('map', {
+      center: [39.73, -104.99],
+      zoom: 10,
+      layers: [grayscale, cities]
+    });
+
+    var baseLayers = {
+      "Grayscale": grayscale,
+      "Streets": streets
+    };
+
+    // Overlay layers are grouped
+    var groupedOverlays = {
+      "Random": {
+        "Dogs": dogs,
+        "Cats": cats,
+        "Landmarks": [
+          { name: "Cities", layer: cities },
+          { name: "Restaurants", layer: restaurants }
+        ]
+      }
+    };
+
+    // Make the "Landmarks" group exclusive (use radio inputs)
+    var options = { exclusiveGroups: ["Landmarks"] };
+
+    // Use the custom grouped layer control, not "L.control.layers"
+    var layerControl = L.control.groupedLayers(baseLayers, groupedOverlays, options);
+    map.addControl(layerControl);
+
+    // Remove and add a layer
+    //layerControl.removeLayer(cities);
+    //layerControl.addOverlay(cities, "Cities", "New Category");
+  </script>
+</body>
+</html>

--- a/src/leaflet.groupedlayercontrol.css
+++ b/src/leaflet.groupedlayercontrol.css
@@ -16,3 +16,8 @@ select.leaflet-control-layers-selector {
   margin-left: 10px;
   margin-right: 10px;
 }
+
+.leaflet-control-layers-overlays th {
+  border-bottom: solid black 1px;
+}
+

--- a/src/leaflet.groupedlayercontrol.css
+++ b/src/leaflet.groupedlayercontrol.css
@@ -11,3 +11,8 @@
 .leaflet-control-layers-group label {
   padding-left: .5em;
 }
+
+select.leaflet-control-layers-selector {
+  margin-left: 10px;
+  margin-right: 10px;
+}

--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -11,7 +11,8 @@ L.Control.GroupedLayers = L.Control.extend({
     exclusiveGroups: []
   },
 
-  initialize: function (baseLayers, groupedOverlays, options) {
+  initialize: function (baseLayers, groupedOverlays, options)
+  {
     var i, j;
     L.Util.setOptions(this, options);
 
@@ -21,18 +22,22 @@ L.Control.GroupedLayers = L.Control.extend({
     this._groupList = [];
     this._domGroups = [];
 
-    for (i in baseLayers) {
+    for (i in baseLayers)
+    {
       this._addLayer(baseLayers[i], i);
     }
 
-    for (i in groupedOverlays) {
-      for (var j in groupedOverlays[i]) {
+    for (i in groupedOverlays)
+    {
+      for (var j in groupedOverlays[i])
+      {
         this._addLayer(groupedOverlays[i][j], j, i, true);
       }
     }
   },
 
-  onAdd: function (map) {
+  onAdd: function (map)
+  {
     this._initLayout();
     this._update();
 
@@ -43,49 +48,58 @@ L.Control.GroupedLayers = L.Control.extend({
     return this._container;
   },
 
-  onRemove: function (map) {
+  onRemove: function (map)
+  {
     map
         .off('layeradd', this._onLayerChange)
         .off('layerremove', this._onLayerChange);
   },
 
-  addBaseLayer: function (layer, name) {
+  addBaseLayer: function (layer, name)
+  {
     this._addLayer(layer, name);
     this._update();
     return this;
   },
 
-  addOverlay: function (layer, name, group) {
+  addOverlay: function (layer, name, group)
+  {
     this._addLayer(layer, name, group, true);
     this._update();
     return this;
   },
 
-  removeLayer: function (layer) {
+  removeLayer: function (layer)
+  {
     var id = L.Util.stamp(layer);
     delete this._layers[id];
     this._update();
     return this;
   },
 
-  _initLayout: function () {
+  _initLayout: function ()
+  {
     var className = 'leaflet-control-layers',
         container = this._container = L.DomUtil.create('div', className);
 
     //Makes this work on IE10 Touch devices by stopping it from firing a mouseout event when the touch is released
     container.setAttribute('aria-haspopup', true);
 
-    if (!L.Browser.touch) {
+    if (!L.Browser.touch)
+    {
       L.DomEvent.disableClickPropagation(container);
       L.DomEvent.on(container, 'wheel', L.DomEvent.stopPropagation);
-    } else {
+    } else
+    {
       L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
     }
 
     var form = this._form = L.DomUtil.create('form', className + '-list');
 
-    if (this.options.collapsed) {
-      if (!L.Browser.android) {
+    if (this.options.collapsed)
+    {
+      if (!L.Browser.android)
+      {
         L.DomEvent
             .on(container, 'mouseover', this._expand, this)
             .on(container, 'mouseout', this._collapse, this);
@@ -94,18 +108,21 @@ L.Control.GroupedLayers = L.Control.extend({
       link.href = '#';
       link.title = 'Layers';
 
-      if (L.Browser.touch) {
+      if (L.Browser.touch)
+      {
         L.DomEvent
             .on(link, 'click', L.DomEvent.stop)
             .on(link, 'click', this._expand, this);
       }
-      else {
+      else
+      {
         L.DomEvent.on(link, 'focus', this._expand, this);
       }
 
       this._map.on('click', this._collapse, this);
       // TODO keyboard accessibility
-    } else {
+    } else
+    {
       this._expand();
     }
 
@@ -116,7 +133,8 @@ L.Control.GroupedLayers = L.Control.extend({
     container.appendChild(form);
   },
 
-  _addLayer: function (layer, name, group, overlay) {
+  _addLayer: function (layer, name, group, overlay)
+  {
     var id = L.Util.stamp(layer);
 
     this._layers[id] = {
@@ -128,7 +146,8 @@ L.Control.GroupedLayers = L.Control.extend({
     group = group || '';
     var groupId = this._indexOf(this._groupList, group);
 
-    if (groupId === -1) {
+    if (groupId === -1)
+    {
       groupId = this._groupList.push(group) - 1;
     }
 
@@ -140,14 +159,34 @@ L.Control.GroupedLayers = L.Control.extend({
       exclusive: exclusive
     };
 
-    if (this.options.autoZIndex && layer.setZIndex) {
+    if (this.options.autoZIndex)
+    {
+      if (layer.length)
+      {
+        var self = this;
+        layer.forEach(function (item)
+        {
+          if (item.layer.setZIndex)
+          {
+            self._lastZIndex++;
+            item.layer.setZIndex(self._lastZIndex);
+          }
+        });
+      } else
+      {
+        if (layer.setZIndex)
+        {
       this._lastZIndex++;
       layer.setZIndex(this._lastZIndex);
     }
+      }
+    }
   },
 
-  _update: function () {
-    if (!this._container) {
+  _update: function ()
+  {
+    if (!this._container)
+    {
       return;
     }
 
@@ -159,7 +198,8 @@ L.Control.GroupedLayers = L.Control.extend({
         overlaysPresent = false,
         i, obj;
 
-    for (i in this._layers) {
+    for (i in this._layers)
+    {
       obj = this._layers[i];
       this._addItem(obj);
       overlaysPresent = overlaysPresent || obj.overlay;
@@ -169,12 +209,14 @@ L.Control.GroupedLayers = L.Control.extend({
     this._separator.style.display = overlaysPresent && baseLayersPresent ? '' : 'none';
   },
 
-  _onLayerChange: function (e) {
+  _onLayerChange: function (e)
+  {
     var obj = this._layers[L.Util.stamp(e.layer)];
 
     if (!obj) { return; }
 
-    if (!this._handlingClick) {
+    if (!this._handlingClick)
+    {
       this._update();
     }
 
@@ -182,16 +224,19 @@ L.Control.GroupedLayers = L.Control.extend({
       (e.type === 'layeradd' ? 'overlayadd' : 'overlayremove') :
       (e.type === 'layeradd' ? 'baselayerchange' : null);
 
-    if (type) {
+    if (type)
+    {
       this._map.fire(type, obj);
     }
   },
 
   // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
-  _createRadioElement: function (name, checked) {
+  _createRadioElement: function (name, checked)
+  {
 
     var radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="' + name + '"';
-    if (checked) {
+    if (checked)
+    {
       radioHtml += ' checked="checked"';
     }
     radioHtml += '/>';
@@ -202,23 +247,65 @@ L.Control.GroupedLayers = L.Control.extend({
     return radioFragment.firstChild;
   },
 
-  _addItem: function (obj) {
+  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
+  _createSelectElement: function (layers)
+  {
+    // NOTE: Opening the select element and displaying the options list fires the select.onmouseout event which 
+    // propagates to the div container and collapses the layer control. The onmouseout handler below will
+    // stop this event from propagating. It has an if-else clause because IE handles this differently than other browsers.
+    var selectHtml = '<select class="leaflet-control-layers-selector" onmouseout="if (arguments[0]) {arguments[0].stopPropagation();} else {window.event.cancelBubble();}">';
+
+    for (var i = 0; i < layers.length; i++)
+    {
+      selectHtml += '<option value="' + layers[i].name + '"';
+      if (this._map.hasLayer(layers[i].layer))
+      {
+        selectHtml += " selected='selected'";
+      }
+      selectHtml += '>' + layers[i].name + "</option>";
+    }
+    selectHtml += '</select>';
+
+    var selectFragment = document.createElement('div');
+    selectFragment.innerHTML = selectHtml;
+
+    return selectFragment.firstChild;
+  },
+
+  _hasAtLeastOneLayer: function (layers)
+  {
+    for (var i = 0; i < layers.length; i++)
+    {
+      if (this._map.hasLayer(layers[i].layer))
+      {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  _addItem: function (obj)
+  {
     var label = document.createElement('label'),
         input,
-        checked = this._map.hasLayer(obj.layer),
+        checked = obj.layer.length ? this._hasAtLeastOneLayer(obj.layer) : this._map.hasLayer(obj.layer),
         container;
 
-    if (obj.overlay) {
-      if (obj.group.exclusive) {
+    if (obj.overlay)
+    {
+      if (obj.group.exclusive)
+      {
         groupRadioName = 'leaflet-exclusive-group-layer-' + obj.group.id;
         input = this._createRadioElement(groupRadioName, checked);
-      } else {
+      } else
+      {
         input = document.createElement('input');
         input.type = 'checkbox';
         input.className = 'leaflet-control-layers-selector';
         input.defaultChecked = checked;
       }
-    } else {
+    } else
+    {
       input = this._createRadioElement('leaflet-base-layers', checked);
     }
 
@@ -232,13 +319,23 @@ L.Control.GroupedLayers = L.Control.extend({
     label.appendChild(input);
     label.appendChild(name);
 
-    if (obj.overlay) {
+    if (obj.layer.length)
+    {
+      var select = this._createSelectElement(obj.layer);
+      L.DomEvent.on(select, 'change', this._onInputClick, this);
+      select.layerId = L.Util.stamp(obj.layer);
+      label.appendChild(select);
+    }
+
+    if (obj.overlay)
+    {
       container = this._overlaysList;
 
       var groupContainer = this._domGroups[obj.group.id];
 
       // Create the group container if it doesn't exist
-      if (!groupContainer) {
+      if (!groupContainer)
+      {
         groupContainer = document.createElement('div');
         groupContainer.className = 'leaflet-control-layers-group';
         groupContainer.id = 'leaflet-control-layers-group-' + obj.group.id;
@@ -254,7 +351,8 @@ L.Control.GroupedLayers = L.Control.extend({
       }
 
       container = groupContainer;
-    } else {
+    } else
+    {
       container = this._baseLayersList;
     }
 
@@ -263,39 +361,93 @@ L.Control.GroupedLayers = L.Control.extend({
     return label;
   },
 
-  _onInputClick: function () {
+  _getSelect: function (selects, layerId)
+  {
+    for (var i = 0; i < selects.length; i++)
+    {
+      if (selects[i].layerId === layerId)
+      {
+        return selects[i];
+      }
+    }
+    return null;
+  },
+
+  _onInputClick: function ()
+  {
     var i, input, obj,
         inputs = this._form.getElementsByTagName('input'),
-        inputsLen = inputs.length;
+        inputsLen = inputs.length,
+        selects = this._form.getElementsByTagName('select'),
+        select,
+        layer, selected, visible;
 
     this._handlingClick = true;
 
-    for (i = 0; i < inputsLen; i++) {
+    for (i = 0; i < inputsLen; i++)
+    {
       input = inputs[i];
       obj = this._layers[input.layerId];
 
-      if (input.checked && !this._map.hasLayer(obj.layer)) {
+      if (input.checked)
+      {
+        if (obj.layer.length)
+        {
+          for (var j = 0; j < obj.layer.length; j++)
+          {
+            layer = obj.layer[j].layer;
+            select = this._getSelect(selects, input.layerId);
+            selected = select[j].selected;
+            visible = this._map.hasLayer(layer);
+            if (visible && !selected) { this._map.removeLayer(layer); }
+            else if (!visible && selected) { this._map.addLayer(layer); }
+          }
+        } else
+        {
+          if (!this._map.hasLayer(obj.layer))
+          {
         this._map.addLayer(obj.layer);
-
-      } else if (!input.checked && this._map.hasLayer(obj.layer)) {
+          }
+        }
+      } else
+      {
+        if (obj.layer.length)
+        {
+          for (var j = 0; j < obj.layer.length; j++)
+          {
+            layer = obj.layer[j].layer;
+            visible = this._map.hasLayer(layer);
+            if (visible) { this._map.removeLayer(layer); }
+          }
+        } else
+        {
+          if (this._map.hasLayer(obj.layer))
+          {
         this._map.removeLayer(obj.layer);
+      }
+    }
       }
     }
 
     this._handlingClick = false;
   },
 
-  _expand: function () {
+  _expand: function ()
+  {
     L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
   },
 
-  _collapse: function () {
+  _collapse: function ()
+  {
     this._container.className = this._container.className.replace(' leaflet-control-layers-expanded', '');
   },
 
-  _indexOf: function (arr, obj) {
-    for (var i = 0, j = arr.length; i < j; i++) {
-      if (arr[i] === obj) {
+  _indexOf: function (arr, obj)
+  {
+    for (var i = 0, j = arr.length; i < j; i++)
+    {
+      if (arr[i] === obj)
+      {
         return i;
       }
     }
@@ -303,6 +455,7 @@ L.Control.GroupedLayers = L.Control.extend({
   }
 });
 
-L.control.groupedLayers = function (baseLayers, groupedOverlays, options) {
+L.control.groupedLayers = function (baseLayers, groupedOverlays, options)
+{
   return new L.Control.GroupedLayers(baseLayers, groupedOverlays, options);
 };

--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -11,8 +11,7 @@ L.Control.GroupedLayers = L.Control.extend({
     exclusiveGroups: []
   },
 
-  initialize: function (baseLayers, groupedOverlays, options)
-  {
+  initialize: function (baseLayers, groupedOverlays, options) {
     var i, j;
     L.Util.setOptions(this, options);
 
@@ -22,22 +21,18 @@ L.Control.GroupedLayers = L.Control.extend({
     this._groupList = [];
     this._domGroups = [];
 
-    for (i in baseLayers)
-    {
+    for (i in baseLayers) {
       this._addLayer(baseLayers[i], i);
     }
 
-    for (i in groupedOverlays)
-    {
-      for (var j in groupedOverlays[i])
-      {
+    for (i in groupedOverlays) {
+      for (var j in groupedOverlays[i]) {
         this._addLayer(groupedOverlays[i][j], j, i, true);
       }
     }
   },
 
-  onAdd: function (map)
-  {
+  onAdd: function (map) {
     this._initLayout();
     this._update();
 
@@ -48,58 +43,49 @@ L.Control.GroupedLayers = L.Control.extend({
     return this._container;
   },
 
-  onRemove: function (map)
-  {
+  onRemove: function (map) {
     map
         .off('layeradd', this._onLayerChange)
         .off('layerremove', this._onLayerChange);
   },
 
-  addBaseLayer: function (layer, name)
-  {
+  addBaseLayer: function (layer, name) {
     this._addLayer(layer, name);
     this._update();
     return this;
   },
 
-  addOverlay: function (layer, name, group)
-  {
+  addOverlay: function (layer, name, group) {
     this._addLayer(layer, name, group, true);
     this._update();
     return this;
   },
 
-  removeLayer: function (layer)
-  {
+  removeLayer: function (layer) {
     var id = L.Util.stamp(layer);
     delete this._layers[id];
     this._update();
     return this;
   },
 
-  _initLayout: function ()
-  {
+  _initLayout: function () {
     var className = 'leaflet-control-layers',
         container = this._container = L.DomUtil.create('div', className);
 
     //Makes this work on IE10 Touch devices by stopping it from firing a mouseout event when the touch is released
     container.setAttribute('aria-haspopup', true);
 
-    if (!L.Browser.touch)
-    {
+    if (!L.Browser.touch) {
       L.DomEvent.disableClickPropagation(container);
       L.DomEvent.on(container, 'wheel', L.DomEvent.stopPropagation);
-    } else
-    {
+    } else {
       L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
     }
 
     var form = this._form = L.DomUtil.create('form', className + '-list');
 
-    if (this.options.collapsed)
-    {
-      if (!L.Browser.android)
-      {
+    if (this.options.collapsed) {
+      if (!L.Browser.android) {
         L.DomEvent
             .on(container, 'mouseover', this._expand, this)
             .on(container, 'mouseout', this._collapse, this);
@@ -108,21 +94,18 @@ L.Control.GroupedLayers = L.Control.extend({
       link.href = '#';
       link.title = 'Layers';
 
-      if (L.Browser.touch)
-      {
+      if (L.Browser.touch) {
         L.DomEvent
             .on(link, 'click', L.DomEvent.stop)
             .on(link, 'click', this._expand, this);
       }
-      else
-      {
+      else {
         L.DomEvent.on(link, 'focus', this._expand, this);
       }
 
       this._map.on('click', this._collapse, this);
       // TODO keyboard accessibility
-    } else
-    {
+    } else {
       this._expand();
     }
 
@@ -133,8 +116,7 @@ L.Control.GroupedLayers = L.Control.extend({
     container.appendChild(form);
   },
 
-  _addLayer: function (layer, name, group, overlay)
-  {
+  _addLayer: function (layer, name, group, overlay) {
     var id = L.Util.stamp(layer);
 
     this._layers[id] = {
@@ -146,8 +128,7 @@ L.Control.GroupedLayers = L.Control.extend({
     group = group || '';
     var groupId = this._indexOf(this._groupList, group);
 
-    if (groupId === -1)
-    {
+    if (groupId === -1) {
       groupId = this._groupList.push(group) - 1;
     }
 
@@ -159,34 +140,26 @@ L.Control.GroupedLayers = L.Control.extend({
       exclusive: exclusive
     };
 
-    if (this.options.autoZIndex)
-    {
-      if (layer.length)
-      {
+    if (this.options.autoZIndex) {
+      if (layer.length) {
         var self = this;
-        layer.forEach(function (item)
-        {
-          if (item.layer.setZIndex)
-          {
+        layer.forEach(function (item) {
+          if (item.layer.setZIndex) {
             self._lastZIndex++;
             item.layer.setZIndex(self._lastZIndex);
           }
         });
-      } else
-      {
-        if (layer.setZIndex)
-        {
-      this._lastZIndex++;
-      layer.setZIndex(this._lastZIndex);
-    }
+      } else {
+        if (layer.setZIndex) {
+          this._lastZIndex++;
+          layer.setZIndex(this._lastZIndex);
+        }
       }
     }
   },
 
-  _update: function ()
-  {
-    if (!this._container)
-    {
+  _update: function () {
+    if (!this._container) {
       return;
     }
 
@@ -198,8 +171,7 @@ L.Control.GroupedLayers = L.Control.extend({
         overlaysPresent = false,
         i, obj;
 
-    for (i in this._layers)
-    {
+    for (i in this._layers) {
       obj = this._layers[i];
       this._addItem(obj);
       overlaysPresent = overlaysPresent || obj.overlay;
@@ -209,14 +181,12 @@ L.Control.GroupedLayers = L.Control.extend({
     this._separator.style.display = overlaysPresent && baseLayersPresent ? '' : 'none';
   },
 
-  _onLayerChange: function (e)
-  {
+  _onLayerChange: function (e) {
     var obj = this._layers[L.Util.stamp(e.layer)];
 
     if (!obj) { return; }
 
-    if (!this._handlingClick)
-    {
+    if (!this._handlingClick) {
       this._update();
     }
 
@@ -224,19 +194,16 @@ L.Control.GroupedLayers = L.Control.extend({
       (e.type === 'layeradd' ? 'overlayadd' : 'overlayremove') :
       (e.type === 'layeradd' ? 'baselayerchange' : null);
 
-    if (type)
-    {
+    if (type) {
       this._map.fire(type, obj);
     }
   },
 
   // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
-  _createRadioElement: function (name, checked)
-  {
+  _createRadioElement: function (name, checked) {
 
     var radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="' + name + '"';
-    if (checked)
-    {
+    if (checked) {
       radioHtml += ' checked="checked"';
     }
     radioHtml += '/>';
@@ -248,18 +215,15 @@ L.Control.GroupedLayers = L.Control.extend({
   },
 
   // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
-  _createSelectElement: function (layers)
-  {
+  _createSelectElement: function (layers) {
     // NOTE: Opening the select element and displaying the options list fires the select.onmouseout event which 
     // propagates to the div container and collapses the layer control. The onmouseout handler below will
     // stop this event from propagating. It has an if-else clause because IE handles this differently than other browsers.
     var selectHtml = '<select class="leaflet-control-layers-selector" onmouseout="if (arguments[0]) {arguments[0].stopPropagation();} else {window.event.cancelBubble();}">';
 
-    for (var i = 0; i < layers.length; i++)
-    {
+    for (var i = 0; i < layers.length; i++) {
       selectHtml += '<option value="' + layers[i].name + '"';
-      if (this._map.hasLayer(layers[i].layer))
-      {
+      if (this._map.hasLayer(layers[i].layer)) {
         selectHtml += " selected='selected'";
       }
       selectHtml += '>' + layers[i].name + "</option>";
@@ -272,40 +236,32 @@ L.Control.GroupedLayers = L.Control.extend({
     return selectFragment.firstChild;
   },
 
-  _hasAtLeastOneLayer: function (layers)
-  {
-    for (var i = 0; i < layers.length; i++)
-    {
-      if (this._map.hasLayer(layers[i].layer))
-      {
+  _hasAtLeastOneLayer: function (layers) {
+    for (var i = 0; i < layers.length; i++) {
+      if (this._map.hasLayer(layers[i].layer)) {
         return true;
       }
     }
     return false;
   },
 
-  _addItem: function (obj)
-  {
+  _addItem: function (obj) {
     var label = document.createElement('label'),
         input,
         checked = obj.layer.length ? this._hasAtLeastOneLayer(obj.layer) : this._map.hasLayer(obj.layer),
         container;
 
-    if (obj.overlay)
-    {
-      if (obj.group.exclusive)
-      {
+    if (obj.overlay) {
+      if (obj.group.exclusive) {
         groupRadioName = 'leaflet-exclusive-group-layer-' + obj.group.id;
         input = this._createRadioElement(groupRadioName, checked);
-      } else
-      {
+      } else {
         input = document.createElement('input');
         input.type = 'checkbox';
         input.className = 'leaflet-control-layers-selector';
         input.defaultChecked = checked;
       }
-    } else
-    {
+    } else {
       input = this._createRadioElement('leaflet-base-layers', checked);
     }
 
@@ -319,23 +275,20 @@ L.Control.GroupedLayers = L.Control.extend({
     label.appendChild(input);
     label.appendChild(name);
 
-    if (obj.layer.length)
-    {
+    if (obj.layer.length) {
       var select = this._createSelectElement(obj.layer);
       L.DomEvent.on(select, 'change', this._onInputClick, this);
       select.layerId = L.Util.stamp(obj.layer);
       label.appendChild(select);
     }
 
-    if (obj.overlay)
-    {
+    if (obj.overlay) {
       container = this._overlaysList;
 
       var groupContainer = this._domGroups[obj.group.id];
 
       // Create the group container if it doesn't exist
-      if (!groupContainer)
-      {
+      if (!groupContainer) {
         groupContainer = document.createElement('div');
         groupContainer.className = 'leaflet-control-layers-group';
         groupContainer.id = 'leaflet-control-layers-group-' + obj.group.id;
@@ -351,8 +304,7 @@ L.Control.GroupedLayers = L.Control.extend({
       }
 
       container = groupContainer;
-    } else
-    {
+    } else {
       container = this._baseLayersList;
     }
 
@@ -361,20 +313,16 @@ L.Control.GroupedLayers = L.Control.extend({
     return label;
   },
 
-  _getSelect: function (selects, layerId)
-  {
-    for (var i = 0; i < selects.length; i++)
-    {
-      if (selects[i].layerId === layerId)
-      {
+  _getSelect: function (selects, layerId) {
+    for (var i = 0; i < selects.length; i++) {
+      if (selects[i].layerId === layerId) {
         return selects[i];
       }
     }
     return null;
   },
 
-  _onInputClick: function ()
-  {
+  _onInputClick: function () {
     var i, input, obj,
         inputs = this._form.getElementsByTagName('input'),
         inputsLen = inputs.length,
@@ -384,17 +332,13 @@ L.Control.GroupedLayers = L.Control.extend({
 
     this._handlingClick = true;
 
-    for (i = 0; i < inputsLen; i++)
-    {
+    for (i = 0; i < inputsLen; i++) {
       input = inputs[i];
       obj = this._layers[input.layerId];
 
-      if (input.checked)
-      {
-        if (obj.layer.length)
-        {
-          for (var j = 0; j < obj.layer.length; j++)
-          {
+      if (input.checked) {
+        if (obj.layer.length) {
+          for (var j = 0; j < obj.layer.length; j++) {
             layer = obj.layer[j].layer;
             select = this._getSelect(selects, input.layerId);
             selected = select[j].selected;
@@ -402,52 +346,40 @@ L.Control.GroupedLayers = L.Control.extend({
             if (visible && !selected) { this._map.removeLayer(layer); }
             else if (!visible && selected) { this._map.addLayer(layer); }
           }
-        } else
-        {
-          if (!this._map.hasLayer(obj.layer))
-          {
-        this._map.addLayer(obj.layer);
+        } else {
+          if (!this._map.hasLayer(obj.layer)) {
+            this._map.addLayer(obj.layer);
           }
         }
-      } else
-      {
-        if (obj.layer.length)
-        {
-          for (var j = 0; j < obj.layer.length; j++)
-          {
+      } else {
+        if (obj.layer.length) {
+          for (var j = 0; j < obj.layer.length; j++) {
             layer = obj.layer[j].layer;
             visible = this._map.hasLayer(layer);
             if (visible) { this._map.removeLayer(layer); }
           }
-        } else
-        {
-          if (this._map.hasLayer(obj.layer))
-          {
-        this._map.removeLayer(obj.layer);
-      }
-    }
+        } else {
+          if (this._map.hasLayer(obj.layer)) {
+            this._map.removeLayer(obj.layer);
+          }
+        }
       }
     }
 
     this._handlingClick = false;
   },
 
-  _expand: function ()
-  {
+  _expand: function () {
     L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
   },
 
-  _collapse: function ()
-  {
+  _collapse: function () {
     this._container.className = this._container.className.replace(' leaflet-control-layers-expanded', '');
   },
 
-  _indexOf: function (arr, obj)
-  {
-    for (var i = 0, j = arr.length; i < j; i++)
-    {
-      if (arr[i] === obj)
-      {
+  _indexOf: function (arr, obj) {
+    for (var i = 0, j = arr.length; i < j; i++) {
+      if (arr[i] === obj) {
         return i;
       }
     }
@@ -455,7 +387,6 @@ L.Control.GroupedLayers = L.Control.extend({
   }
 });
 
-L.control.groupedLayers = function (baseLayers, groupedOverlays, options)
-{
+L.control.groupedLayers = function (baseLayers, groupedOverlays, options) {
   return new L.Control.GroupedLayers(baseLayers, groupedOverlays, options);
 };

--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -1,36 +1,162 @@
 /* global L */
 
+// A wrapper object around a Leaflet layer object that is used for defining layer control behavior.
+//  layer: The layer object to be controlled (REQUIRED).
+//  name: The caption that should be used to display the layer in the layer control (REQUIRED).
+//  groupName: If more than one LayerControlItem is given the same groupName, they will combined in a select (dropdown)
+//    control which appears as a single entry in the layer control. The groupName will be used as a caption. (DEFAULT = name argument).
+//  base: boolean - true if this is a base layer, false if this is an overlay layer (DEFAULT = false).
+//  labelable: boolean - true if this layer can be labelled (DEFAULT = false).
+function LayerControlItem(layer, name, groupName, base, labelable) {
+  this.layer = layer;
+  this.name = name;
+  this.groupName = groupName || name;
+  this.base = !!base;
+  this.labelable = !!labelable;
+}
+
+// Enumeration of all possible clickable HTML elements for each layer group.
+var LayerControlElementType = {
+  VisibilityRadio: 1,
+  VisibilityCheckbox: 2,
+  LabelCheckbox: 3,
+  LayerSelect: 4
+};
+
+// This is an internal class, used to group LayerControlItems by groupName.
+// Since each table row in the layer control is a single LayerControlGroup rather than a LayerControl item, 
+// all the HTML elements are associated with a group rather than an item.
+function LayerControlGroup(layerControlItems, name, base) {
+  this.layerControlItems = layerControlItems;
+  this.name = name;
+  this.base = !!base;
+
+  this._anyLayerVisible = function (map) {
+    for (var i in this.layerControlItems) {
+      if (map.hasLayer(this.layerControlItems[i].layer)) return true;
+    }
+    return false;
+  };
+
+  this.anyLabelable = function () {
+    for (var i in this.layerControlItems) {
+      if (this.layerControlItems[i].labelable) return true;
+    }
+    return false;
+  };
+
+  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
+  this.createVisibleInputElement = function (map) {
+    var checked = this._anyLayerVisible(map);
+    if (this.base) {
+      var radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="leaflet-base-layers"';
+      //var radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="leaflet-exclusive-group-layer-' + this.group + '"';
+      if (checked) {
+        radioHtml += ' checked="checked"';
+      }
+      radioHtml += '/>';
+      var radioFragment = document.createElement('div');
+      radioFragment.innerHTML = radioHtml;
+      radioFragment.firstChild.layerControlElementType = LayerControlElementType.VisibilityRadio;
+      radioFragment.firstChild.groupName = this.name;
+      return radioFragment.firstChild;
+    } else {
+      var input = document.createElement('input');
+      input.type = 'checkbox';
+      input.className = 'leaflet-control-layers-selector';
+      input.defaultChecked = checked;
+      input.layerControlElementType = LayerControlElementType.VisibilityCheckbox;
+      input.groupName = this.name;
+      return input;
+    }
+  };
+
+  this.createLabelInputElement = function () {
+    var input = document.createElement('input');
+    input.type = 'checkbox';
+    input.className = 'leaflet-control-layers-selector';
+    input.defaultChecked = false;
+    input.layerControlType = "label";
+    input.layerControlElementType = LayerControlElementType.LabelCheckbox;
+    input.groupName = this.name;
+    return input;
+  };
+
+  this.createNameSpanElement = function () {
+    var span = document.createElement('span');
+    span.innerHTML = ' ' + this.name;
+    span.groupName = name;
+    return span;
+  };
+
+  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
+  this.createSelectElement = function (map) {
+    // NOTE: Opening the select element and displaying the options list fires the select.onmouseout event which 
+    // propagates to the div container and collapses the layer control. The onmouseout handler below will
+    // stop this event from propagating. It has an if-else clause because IE handles this differently than other browsers.
+    var selectHtml = '<select class="leaflet-control-layers-selector" onmouseout="if (arguments[0]) {arguments[0].stopPropagation();} else {window.event.cancelBubble();}">';
+
+    for (var i = 0; i < this.layerControlItems.length; i++) {
+      selectHtml += '<option value="' + this.layerControlItems[i].name + '"';
+      if (map.hasLayer(this.layerControlItems[i].layer)) {
+        selectHtml += " selected='selected'";
+      }
+      selectHtml += '>' + this.layerControlItems[i].name + "</option>";
+    }
+    selectHtml += '</select>';
+
+    var selectFragment = document.createElement('div');
+    selectFragment.innerHTML = selectHtml;
+    selectFragment.firstChild.layerControlElementType = LayerControlElementType.LayerSelect;
+    selectFragment.firstChild.groupName = this.name;
+    return selectFragment.firstChild;
+  };
+}
+
+
 // A layer control which provides for layer groupings.
 // Author: Ishmael Smyrnow
+// Revised: Matthew Katinsky
 L.Control.GroupedLayers = L.Control.extend({
-
   options: {
     collapsed: true,
     position: 'topright',
     autoZIndex: true,
-    exclusiveGroups: [],
-    labelLayers: []
+    labelCallback: null
   },
 
-  initialize: function (baseLayers, groupedOverlays, options) {
-    var i, j;
+  initialize: function (layerControlItems, options) {
+    var i;
     L.Util.setOptions(this, options);
 
-    this._layers = {};
+    this._layerControlItems = {};
+    this._groups = {};
     this._lastZIndex = 0;
     this._handlingClick = false;
-    this._groupList = [];
-    this._domGroups = [];
 
-    for (i in baseLayers) {
-      this._addLayer(baseLayers[i], i);
+    for (i in layerControlItems) {
+      this._addLayerControlItem(layerControlItems[i]);
     }
+  },
 
-    for (i in groupedOverlays) {
-      for (var j in groupedOverlays[i]) {
-        this._addLayer(groupedOverlays[i][j], j, i, true);
+  _addLayerControlItem: function (layerControlItem) {
+    var id = L.Util.stamp(layerControlItem.layer);
+
+    this._layerControlItems[id] = layerControlItem;
+
+    if (this.options.autoZIndex) {
+      if (layerControlItem.layer.setZIndex) {
+        this._lastZIndex++;
+        layerControlItem.layer.setZIndex(this._lastZIndex);
       }
     }
+
+    var groupName = layerControlItem.groupName;
+    if (!this._groups[groupName]) {
+      var group = new LayerControlGroup([], layerControlItem.groupName, layerControlItem.base);
+      this._groups[groupName] = group;
+    }
+    this._groups[groupName].layerControlItems.push(layerControlItem);
   },
 
   onAdd: function (map) {
@@ -38,40 +164,47 @@ L.Control.GroupedLayers = L.Control.extend({
     this._update();
 
     map
-        .on('layeradd', this._onLayerChange, this)
-        .on('layerremove', this._onLayerChange, this);
+      .on('layeradd', this._onLayerChange, this)
+      .on('layerremove', this._onLayerChange, this);
 
     return this._container;
   },
 
   onRemove: function (map) {
     map
-        .off('layeradd', this._onLayerChange)
-        .off('layerremove', this._onLayerChange);
+      .off('layeradd', this._onLayerChange)
+      .off('layerremove', this._onLayerChange);
   },
 
   addBaseLayer: function (layer, name) {
-    this._addLayer(layer, name);
+    this._addLayerControlItem(new LayerControlItem(layer, name, true));
     this._update();
     return this;
   },
 
   addOverlay: function (layer, name, group) {
-    this._addLayer(layer, name, group, true);
+    this._addLayerControlItem(new _addLayerControlItem(layer, name, false, group));
     this._update();
     return this;
   },
 
   removeLayer: function (layer) {
     var id = L.Util.stamp(layer);
-    delete this._layers[id];
+    var layerControlItem = this._layerControlItems[id];
+    if (layerControlItem && layerControlItem.groupName && this._groups[layerControlItem.groupName]) {
+      var group = this._groups[layerControlItem.groupName];
+      var index = group.indexOf(layerControlItem);
+      if (index > -1) group.splice(index, 1);
+      if (group.length === 0) delete this._groups[layerControlItem.groupName];
+    }
+    delete this._layerControlItems[id];
     this._update();
     return this;
   },
 
   _initLayout: function () {
     var className = 'leaflet-control-layers',
-        container = this._container = L.DomUtil.create('div', className);
+      container = this._container = L.DomUtil.create('div', className);
 
     //Makes this work on IE10 Touch devices by stopping it from firing a mouseout event when the touch is released
     container.setAttribute('aria-haspopup', true);
@@ -88,8 +221,8 @@ L.Control.GroupedLayers = L.Control.extend({
     if (this.options.collapsed) {
       if (!L.Browser.android) {
         L.DomEvent
-            .on(container, 'mouseover', this._expand, this)
-            .on(container, 'mouseout', this._collapse, this);
+          .on(container, 'mouseover', this._expand, this)
+          .on(container, 'mouseout', this._collapse, this);
       }
       var link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
       link.href = '#';
@@ -97,10 +230,9 @@ L.Control.GroupedLayers = L.Control.extend({
 
       if (L.Browser.touch) {
         L.DomEvent
-            .on(link, 'click', L.DomEvent.stop)
-            .on(link, 'click', this._expand, this);
-      }
-      else {
+          .on(link, 'click', L.DomEvent.stop)
+          .on(link, 'click', this._expand, this);
+      } else {
         L.DomEvent.on(link, 'focus', this._expand, this);
       }
 
@@ -110,80 +242,60 @@ L.Control.GroupedLayers = L.Control.extend({
       this._expand();
     }
 
-    this._baseLayersList = L.DomUtil.create('div', className + '-base', form);
+    this._baseLayersTable = L.DomUtil.create('table', className + '-base', form);
     this._separator = L.DomUtil.create('div', className + '-separator', form);
-    this._overlaysList = L.DomUtil.create('div', className + '-overlays', form);
+    this._overlaysTable = L.DomUtil.create('table', className + '-overlays', form);
+    this._insertOverlaysTableHeader();
 
     container.appendChild(form);
   },
 
-  _addLayer: function (layer, name, group, overlay) {
-    var id = L.Util.stamp(layer);
-
-    this._layers[id] = {
-      layer: layer,
-      name: name,
-      overlay: overlay
-    };
-
-    group = group || '';
-    var groupId = this._indexOf(this._groupList, group);
-
-    if (groupId === -1) {
-      groupId = this._groupList.push(group) - 1;
+  _insertOverlaysTableHeader: function () {
+    var tr = document.createElement("tr");
+    var visibleImage = document.createElement("img");
+    visibleImage.src = "img/visibility.png";
+    visibleImage.alt = "Toggle layer on/off.";
+    var th = document.createElement("th");
+    th.appendChild(visibleImage);
+    tr.appendChild(th);
+    if (this.options.labelCallback) {
+      var labelImage = document.createElement("img");
+      labelImage.src = "img/label.png";
+      labelImage.alt = "Toggle labels on/off.";
+      th = document.createElement("th");
+      th.appendChild(labelImage);
+      tr.appendChild(th);
     }
-
-    var exclusive = (this._indexOf(this.options.exclusiveGroups, group) != -1);
-
-    this._layers[id].group = {
-      name: group,
-      id: groupId,
-      exclusive: exclusive
-    };
-
-    if (this.options.autoZIndex) {
-      if (layer.length) {
-        var self = this;
-        layer.forEach(function (item) {
-          if (item.layer.setZIndex) {
-            self._lastZIndex++;
-            item.layer.setZIndex(self._lastZIndex);
-          }
-        });
-      } else {
-        if (layer.setZIndex) {
-          this._lastZIndex++;
-          layer.setZIndex(this._lastZIndex);
-        }
-      }
-    }
+    th = document.createElement("th");
+    th.innerHTML = "Layer";
+    tr.appendChild(th);
+    this._overlaysTable.appendChild(tr);
   },
 
   _update: function () {
     if (!this._container) {
       return;
-    }
-
-    this._baseLayersList.innerHTML = '';
-    this._overlaysList.innerHTML = '';
-    this._domGroups.length = 0;
+    };
+    this._baseLayersTable.innerHTML = '';
+    this._overlaysTable.innerHTML = '';
+    this._insertOverlaysTableHeader();
 
     var baseLayersPresent = false,
         overlaysPresent = false,
-        i, obj;
+        name, group;
 
-    for (i in this._layers) {
-      obj = this._layers[i];
-      this._addItem(obj);
-      overlaysPresent = overlaysPresent || obj.overlay;
-      baseLayersPresent = baseLayersPresent || !obj.overlay;
+    for (groupName in this._groups) {
+      var group = this._groups[groupName];
+      this._addGroup(group);
+      overlaysPresent = overlaysPresent || !group.base;
+      baseLayersPresent = baseLayersPresent || group.base;
     }
 
     this._separator.style.display = overlaysPresent && baseLayersPresent ? '' : 'none';
   },
 
   _onLayerChange: function (e) {
-    var obj = this._layers[L.Util.stamp(e.layer)];
+    var obj = this._layerControlItems[L.Util.stamp(e.layer)];
 
     if (!obj) { return; }
 
@@ -191,140 +303,56 @@ L.Control.GroupedLayers = L.Control.extend({
       this._update();
     }
 
-    var type = obj.overlay ?
+    var type = !obj.base ?
       (e.type === 'layeradd' ? 'overlayadd' : 'overlayremove') :
       (e.type === 'layeradd' ? 'baselayerchange' : null);
 
     if (type) {
-      this._map.fire(type, obj);
+      this._map.fire(type, obj.layer);
     }
   },
 
-  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
-  _createRadioElement: function (name, checked) {
-
-    var radioHtml = '<input type="radio" class="leaflet-control-layers-selector" name="' + name + '"';
-    if (checked) {
-      radioHtml += ' checked="checked"';
-    }
-    radioHtml += '/>';
-
-    var radioFragment = document.createElement('div');
-    radioFragment.innerHTML = radioHtml;
-
-    return radioFragment.firstChild;
-  },
-
-  // IE7 bugs out if you create a radio dynamically, so you have to do it this hacky way (see http://bit.ly/PqYLBe)
-  _createSelectElement: function (layers) {
-    // NOTE: Opening the select element and displaying the options list fires the select.onmouseout event which 
-    // propagates to the div container and collapses the layer control. The onmouseout handler below will
-    // stop this event from propagating. It has an if-else clause because IE handles this differently than other browsers.
-    var selectHtml = '<select class="leaflet-control-layers-selector" onmouseout="if (arguments[0]) {arguments[0].stopPropagation();} else {window.event.cancelBubble();}">';
-
-    for (var i = 0; i < layers.length; i++) {
-      selectHtml += '<option value="' + layers[i].name + '"';
-      if (this._map.hasLayer(layers[i].layer)) {
-        selectHtml += " selected='selected'";
-      }
-      selectHtml += '>' + layers[i].name + "</option>";
-    }
-    selectHtml += '</select>';
-
-    var selectFragment = document.createElement('div');
-    selectFragment.innerHTML = selectHtml;
-
-    return selectFragment.firstChild;
-  },
-
-  _hasAtLeastOneLayer: function (layers) {
-    for (var i = 0; i < layers.length; i++) {
-      if (this._map.hasLayer(layers[i].layer)) {
-        return true;
-      }
-    }
-    return false;
-  },
-
-  _addItem: function (obj) {
-    var label = document.createElement('label'),
+  _addGroup: function (group) {
+    //var label = document.createElement('label'),
+    var tr, td,
         input, labelInput,
-        checked = obj.layer.length ? this._hasAtLeastOneLayer(obj.layer) : this._map.hasLayer(obj.layer),
         container, select;
 
-    if (obj.overlay) {
-      if (obj.group.exclusive) {
-        groupRadioName = 'leaflet-exclusive-group-layer-' + obj.group.id;
-        input = this._createRadioElement(groupRadioName, checked);
+    tr = document.createElement('tr');
+
+    input = group.createVisibleInputElement(this._map);
+    //input.layerId = L.Util.stamp(obj.layer);
+    L.DomEvent.on(input, 'click', this._onLayerControlElementClick, this);
+    td = document.createElement('td');
+    td.appendChild(input);
+    tr.appendChild(td);
+
+    if (this.options.labelCallback) {
+      td = document.createElement('td');
+      if (group.anyLabelable()) {
+        labelInput = group.createLabelInputElement();
+        td.appendChild(labelInput);
+        L.DomEvent.on(labelInput, 'click', this._onLayerControlElementClick, this);
       } else {
-        input = document.createElement('input');
-        input.type = 'checkbox';
-        input.className = 'leaflet-control-layers-selector';
-        input.defaultChecked = checked;
+        td.innerHTML = "&nbsp;";
       }
-    } else {
-      input = this._createRadioElement('leaflet-base-layers', checked);
+      tr.appendChild(td);
     }
 
-    input.layerId = L.Util.stamp(obj.layer);
+    td = document.createElement('td');
+    td.appendChild(group.createNameSpanElement());
 
-    L.DomEvent.on(input, 'click', this._onInputClick, this);
-
-    var name = document.createElement('span');
-    name.innerHTML = ' ' + obj.name;
-
-    label.appendChild(input);
-    label.appendChild(name);
-
-    if (obj.layer.length) {
-      select = this._createSelectElement(obj.layer);
-      L.DomEvent.on(select, 'change', this._onInputClick, this);
-      select.layerId = L.Util.stamp(obj.layer);
-      label.appendChild(select);
+    if (group.layerControlItems.length > 1) {
+      select = group.createSelectElement(this._map);
+      L.DomEvent.on(select, 'change', this._onLayerControlElementClick, this);
+      td.appendChild(select);
     }
+    tr.appendChild(td);
 
-    if (this._indexOf(this.options.labelLayers, obj.name) !== -1) {
-      labelInput = document.createElement('input');
-      labelInput.type = 'checkbox';
-      labelInput.className = 'leaflet-control-layers-selector';
-      labelInput.defaultChecked = false;
-      labelInput.layerInput = input;
-      label.appendChild(labelInput);
-      var labelName = document.createElement('span');
-      labelName.innerHTML = ' (labels)';
-      label.appendChild(labelName);
-      L.DomEvent.on(labelInput, 'click', this._onInputClick, this);
-    }
+    container = group.base ? this._baseLayersTable : this._overlaysTable;
+    container.appendChild(tr);
 
-    if (obj.overlay) {
-      container = this._overlaysList;
-
-      var groupContainer = this._domGroups[obj.group.id];
-
-      // Create the group container if it doesn't exist
-      if (!groupContainer) {
-        groupContainer = document.createElement('div');
-        groupContainer.className = 'leaflet-control-layers-group';
-        groupContainer.id = 'leaflet-control-layers-group-' + obj.group.id;
-
-        var groupLabel = document.createElement('span');
-        groupLabel.className = 'leaflet-control-layers-group-name';
-        groupLabel.innerHTML = obj.group.name;
-
-        groupContainer.appendChild(groupLabel);
-        container.appendChild(groupContainer);
-
-        this._domGroups[obj.group.id] = groupContainer;
-      }
-
-      container = groupContainer;
-    } else {
-      container = this._baseLayersList;
-    }
-
-    container.appendChild(label);
-
-    return label;
+    return tr;
   },
 
   _getSelect: function (selects, layerId) {
@@ -336,74 +364,113 @@ L.Control.GroupedLayers = L.Control.extend({
     return null;
   },
 
-  _onInputClick: function () {
-    var i, input, obj,
-        inputs = this._form.getElementsByTagName('input'),
-        inputsLen = inputs.length,
-        selects = this._form.getElementsByTagName('select'),
-        select,
-        layer, selected, visible,
-        labels = [];
+  _onLayerControlElementClick: function (evt) {
+    var i, selectedGroup, selectedLayerControlItem, layerControlItem;
 
     this._handlingClick = true;
 
-    for (i = 0; i < inputsLen; i++) {
-      input = inputs[i];
-      obj = this._layers[input.layerId];
-      if (obj) {
-        if (input.checked) {
-          if (obj.layer.length) {
-            select = this._getSelect(selects, input.layerId);
-            for (var j = 0; j < obj.layer.length; j++) {
-              layer = obj.layer[j].layer;
-              selected = select[j].selected;
-              visible = this._map.hasLayer(layer);
-              if (visible && !selected) {
-                this._map.removeLayer(layer);
-              } else if (!visible && selected) {
-                this._map.addLayer(layer);
-              }
-            }
-          } else {
-            if (!this._map.hasLayer(obj.layer)) {
-              this._map.addLayer(obj.layer);
-            }
-          }
-        } else {
-          if (obj.layer.length) {
-            for (var j = 0; j < obj.layer.length; j++) {
-              layer = obj.layer[j].layer;
-              visible = this._map.hasLayer(layer);
-              if (visible) {
-                this._map.removeLayer(layer);
-              }
-            }
-          } else {
-            if (this._map.hasLayer(obj.layer)) {
-              this._map.removeLayer(obj.layer);
-            }
+    selectedGroup = this._groups[evt.currentTarget.groupName];
+    selectedLayerControlItem = this._getSelectedLayerControlItemForGroup(selectedGroup);
+
+    switch (evt.currentTarget.layerControlElementType) {
+      case LayerControlElementType.VisibilityRadio:
+        for (i in this._layerControlItems) {
+          layerControlItem = this._layerControlItems[i];
+          if (layerControlItem.base) {
+            this._toggerLayerVisibility(layerControlItem.layer, layerControlItem === selectedLayerControlItem);
           }
         }
-      }
-      else if (input.layerInput) {
-        if (input.checked && input.layerInput.checked) {
-          obj = this._layers[input.layerInput.layerId];
-          if (obj.layer.length) {
-            select = this._getSelect(selects, input.layerInput.layerId);
-            for (j = 0; j < obj.layer.length; j++) {
-              if (select[j].selected) {
-                labels.push(obj.layer[j].layer.labelSourceName);
-              }
-            }
-          } else {
-            labels.push(obj.labelSourceName);
-          }
+        break;
+
+      case LayerControlElementType.VisibilityCheckbox:
+        for (i in selectedGroup.layerControlItems) {
+          layerControlItem = selectedGroup.layerControlItems[i];
+          this._toggerLayerVisibility(layerControlItem.layer, layerControlItem === selectedLayerControlItem && evt.currentTarget.checked);
         }
-      }
+        break;
+
+      case LayerControlElementType.LabelCheckbox:
+        if (this.options.labelCallback) {
+          this.options.labelCallback(this._getLabeledLayerControlItems());
+        }
+        break;
+
+      case LayerControlElementType.LayerSelect:
+        for (i in selectedGroup.layerControlItems) {
+          layerControlItem = selectedGroup.layerControlItems[i];
+          this._toggerLayerVisibility(layerControlItem.layer, layerControlItem === selectedLayerControlItem && this._isVisible(selectedGroup));
+        }
+        if (this.options.labelCallback) {
+          this.options.labelCallback(this._getLabeledLayerControlItems());
+        }
+        break;
     }
-    MapActions.updateLabels(labels);
 
     this._handlingClick = false;
+  },
+
+  _toggerLayerVisibility: function (layer, visible) {
+    var currentVisibility = this._map.hasLayer(layer);
+    if (currentVisibility !== visible) {
+      if (visible) {
+        this._map.addLayer(layer);
+      } else {
+        this._map.removeLayer(layer);
+      }
+    }
+  },
+
+  _getLabeledLayerControlItems: function () {
+    var result = [];
+    var inputs = this._form.getElementsByTagName('input');
+    for (var i in inputs) {
+      var input = inputs[i];
+      if (input.layerControlElementType === LayerControlElementType.LabelCheckbox && input.checked) {
+        result.push(this._getSelectedLayerControlItemForGroup(input.groupName));
+      }
+    }
+    return result;
+  },
+  
+  _getSelectedLayerControlItemForGroup: function (group) {
+    if (group.constructor !== LayerControlGroup) { group = this._groups[group]; }
+    if (!group) { return null; }
+    if (group.layerControlItems.length === 1) { return group.layerControlItems[0]; }
+    var select = this._getSelectForGroup(group);
+    var layerControlItemName = select.options[select.selectedIndex].value;
+    var layerControlItem = this._getLayerControlItemByName(group, layerControlItemName);
+    return layerControlItem;
+  },
+
+  _getSelectForGroup: function (group) {
+    if (group.constructor !== LayerControlGroup) { group = this._groups[group]; }
+    if (!group) { return null; }
+    var selects = this._form.getElementsByTagName('select');
+    for (var i in selects) {
+      var select = selects[i];
+      if (select.groupName === group.name) { return select; }
+    }
+    return null;
+  },
+
+  _getLayerControlItemByName: function (group, name) {
+    for (var i in group.layerControlItems) {
+      if (group.layerControlItems[i].name === name) { return group.layerControlItems[i]; }
+    }
+    return null;
+  },
+
+  _isVisible: function (group) {
+    var inputs = this._form.getElementsByTagName('input');
+    for (var i in inputs) {
+      var input = inputs[i];
+      if (input.groupName === group.name &&
+         (input.layerControlElementType === LayerControlElementType.VisibilityRadio ||
+          input.layerControlElementType === LayerControlElementType.VisibilityCheckbox)) {
+        return input.checked;
+      }
+    }
+    return false;
   },
 
   _expand: function () {
@@ -424,6 +491,6 @@ L.Control.GroupedLayers = L.Control.extend({
   }
 });
 
-L.control.groupedLayers = function (baseLayers, groupedOverlays, options) {
-  return new L.Control.GroupedLayers(baseLayers, groupedOverlays, options);
+L.control.groupedLayers = function (layerControlItems, options) {
+  return new L.Control.GroupedLayers(layerControlItems, options);
 };


### PR DESCRIPTION
Love this control, but our list of exclusive layers got so big the radio buttons took up too much real estate on the map when the layer control expanded. I added an alternative. You can now create a single "layer" which is itself an array of name-layer pairs. This displays as a single layer in the control but instead of just a checkbox and label, it is now a checkbox, label, and SELECT control (drop down list). There is a new basic2.html file demonstrating the functionality.

I did not create a new *.min.js file yet.

I'm very new to github, so please excuse if I appear to be taking liberties or have left out anything important. Also, if you think this enhancement is potentially worthwhile but still needs work, let me know and I'll improve it.