### PR TITLE
Add JSPM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,13 @@
   },
   "dependencies": {
     "leaflet": "^0.7.3"
+  },
+  "jspm": {
+    "registry": "jspm",
+    "shim": {
+      "dist/leaflet.groupedlayercontrol.min": [
+        "leaflet"
+      ]
+    }
   }
 }


### PR DESCRIPTION
I use your library within the [JSPM ecosystem](http://jspm.io), however since you don't use any require-like mechanisms but a "global" style, I have to tell jspm explicitly that your main file depends on leaflet, which is what the change in package.json does.

JSPM has a registry which supports [package-overrides](https://github.com/jspm/registry/tree/master/package-overrides) but someone would have to create an override for each new version of your library, which would be quite annoying.

Note that including this JSPM bit shouldn't be a problem, other libraries do it as well: https://github.com/mbostock/d3/blob/master/package.json

I would be happy if you integrate that change.