### PR TITLE
Bug Fix: Prevent 'a is undefined' error when removing layers

### DIFF
--- a/src/leaflet.groupedlayercontrol.js
+++ b/src/leaflet.groupedlayercontrol.js
@@ -66,7 +66,7 @@ L.Control.GroupedLayers = L.Control.extend({
     var id = L.Util.stamp(layer);
     var _layer = this._getLayer(id);
     if (_layer) {
-      delete this._layers[this._layers.indexOf(_layer)];
+      this._layers.splice(this._layers.indexOf(_layer), 1);
     }
     this._update();
     return this;


### PR DESCRIPTION
When a layer is removed via the removeLayer method, the layer is set to undefined in the _layers array using the delete operator, which causes the array to become sparse. This leads to issues when iterating over the array in the _update() method, causing the error.
![removeLayerBug](https://github.com/user-attachments/assets/3bc6a8c9-4c98-4b2f-b976-d0d50daf7b0b)

Check the green marked areas to see the error message, and the way the method is used